### PR TITLE
feat: add optional dag_whitelist to limit optimization to specific DAGs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,10 @@ jobs:
           python bq-job-optimizer-airflow-2/test_dag_execution.py
         env:
           AIRFLOW_HOME: ${{ github.workspace }}/airflow_home
+
+      - name: Run DAG whitelist test
+        run: |
+          export AIRFLOW_HOME=$(pwd)/airflow_home
+          python bq-job-optimizer-airflow-2/test_dag_whitelist.py
+        env:
+          AIRFLOW_HOME: ${{ github.workspace }}/airflow_home

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-30
+
+### Added
+- Optional `dag_whitelist` field on `rabbit_bq_optimizer_config` — when set to a list of DAG IDs, only BigQuery jobs from those DAGs are optimized; all others pass through unmodified. Omitting the field (or `null`) optimizes every DAG (backward compatible); an explicit empty list (`[]`) whitelists nothing and disables optimization for all DAGs. A non-list value or an undeterminable current DAG falls back to the original job as a safe default.
+
 ## [1.0.1] - 2026-06-26
 
 ### Added

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -182,7 +182,7 @@ A setup script `setup_local_test.sh` is provided in the root directory to help y
    This verifies the optional `dag_whitelist` feature:
    - Optimization runs for all DAGs when whitelist is absent or empty
    - Only whitelisted DAGs are optimized when the list is set
-   - Safe fallback when Airflow context is unavailable
+   - Safe fallback (skips optimization) when whitelist is set but Airflow context is unavailable
 
 5. **Cleanup (optional):**
    To remove the test environment (venv and airflow_home directories):

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -78,6 +78,7 @@ The remaining optimizer configuration stays in an Airflow variable. Create a JSO
 
 - `default_pricing_mode` (required): The default pricing mode for jobs. Must be one of: `"on_demand"` or `"slot_based"`
 - `reservation_ids` (required): List of reservation IDs in the format "project:region.reservation-name"
+- `dag_whitelist` (optional): List of DAG IDs to optimize. When omitted or empty, all DAGs are optimized. When specified, only BigQuery jobs from matching DAGs are optimized; all others pass through unmodified.
 
 ### Setting the Configuration
 
@@ -90,9 +91,15 @@ airflow variables set rabbit_bq_optimizer_config '{
     "reservation_ids": [
         "project:region.reservation-name1",
         "project:region.reservation-name2"
+    ],
+    "dag_whitelist": [
+        "my_etl_dag",
+        "my_analytics_dag"
     ]
 }'
 ```
+
+   Omit `dag_whitelist` (or set it to `[]`) to optimize all DAGs.
 
 2. Through the Airflow UI:
    - Go to Admin -> Variables
@@ -164,6 +171,18 @@ A setup script `setup_local_test.sh` is provided in the root directory to help y
    - The plugin intercepts BigQuery jobs
    - The Rabbit optimization API is called with connection credentials
    - The optimized configuration is used
+
+   **Test DAG whitelist filtering:**
+   ```bash
+   source venv/bin/activate
+   export AIRFLOW_HOME=$(pwd)/airflow_home
+   cd bq-job-optimizer-airflow-2
+   python test_dag_whitelist.py
+   ```
+   This verifies the optional `dag_whitelist` feature:
+   - Optimization runs for all DAGs when whitelist is absent or empty
+   - Only whitelisted DAGs are optimized when the list is set
+   - Safe fallback when Airflow context is unavailable
 
 5. **Cleanup (optional):**
    To remove the test environment (venv and airflow_home directories):

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -20,16 +20,16 @@ Already running an older version? See [Updating](#updating).
    - If using `requirements.txt`:
      ```txt
      rabbit-bq-job-optimizer==0.1.18
-     rabbit-bq-optimizer-airflow-plugin==1.0.1
+     rabbit-bq-optimizer-airflow-plugin==1.1.0
      ```
    - If using `constraints.txt`:
      ```txt
      rabbit-bq-job-optimizer==0.1.18
-     rabbit-bq-optimizer-airflow-plugin==1.0.1
+     rabbit-bq-optimizer-airflow-plugin==1.1.0
      ```
    - If using a custom Docker image, add to your Dockerfile:
      ```dockerfile
-     RUN pip install rabbit-bq-job-optimizer==0.1.18 rabbit-bq-optimizer-airflow-plugin==1.0.1
+     RUN pip install rabbit-bq-job-optimizer==0.1.18 rabbit-bq-optimizer-airflow-plugin==1.1.0
      ```
 
    The plugin registers via Airflow's plugin entry point — no file copy into `plugins/` is required.
@@ -59,7 +59,7 @@ Update to the new package versions in your environment dependencies:
 
 ```txt
 rabbit-bq-job-optimizer==0.1.18
-rabbit-bq-optimizer-airflow-plugin==1.0.1
+rabbit-bq-optimizer-airflow-plugin==1.1.0
 ```
 
 Apply the update using your platform's usual process, then restart Airflow components (including the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).
@@ -120,7 +120,7 @@ The remaining optimizer configuration stays in an Airflow variable. Create a JSO
 - `enabled` (required): Must be `true` to run optimization. If omitted, `false`, or the variable is not set, each BigQuery submit bypasses optimization (no API call). Takes effect on the next job without restarting Airflow.
 - `default_pricing_mode` (required when `enabled` is `true`): The default pricing mode for jobs. Must be one of: `"on_demand"` or `"slot_based"`
 - `reservation_ids` (required when `enabled` is `true`): List of reservation IDs in the format "project:region.reservation-name"
-- `dag_whitelist` (optional): List of DAG IDs to optimize. When omitted or empty, all DAGs are optimized. When specified, only BigQuery jobs from matching DAGs are optimized; all others pass through unmodified. Must be a JSON list; any other type is ignored and optimization is skipped as a safe fallback.
+- `dag_whitelist` (optional): List of DAG IDs to optimize. When omitted (or `null`), all DAGs are optimized. When set to a list, only BigQuery jobs from matching DAGs are optimized; all others pass through unmodified — and an **empty list (`[]`) means nothing is whitelisted, so no DAG is optimized**. Must be a JSON list; any other type is ignored and optimization is skipped as a safe fallback.
 
 ### Setting the Configuration
 
@@ -142,7 +142,7 @@ airflow variables set rabbit_bq_optimizer_config '{
 }'
 ```
 
-   Omit `dag_whitelist` (or set it to `[]`) to optimize all DAGs.
+   Omit `dag_whitelist` to optimize all DAGs. Setting it to an empty list (`[]`) whitelists nothing and disables optimization for every DAG.
 
 2. Through the Airflow UI:
    - Go to Admin -> Variables

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -78,7 +78,7 @@ The remaining optimizer configuration stays in an Airflow variable. Create a JSO
 
 - `default_pricing_mode` (required): The default pricing mode for jobs. Must be one of: `"on_demand"` or `"slot_based"`
 - `reservation_ids` (required): List of reservation IDs in the format "project:region.reservation-name"
-- `dag_whitelist` (optional): List of DAG IDs to optimize. When omitted or empty, all DAGs are optimized. When specified, only BigQuery jobs from matching DAGs are optimized; all others pass through unmodified.
+- `dag_whitelist` (optional): List of DAG IDs to optimize. When omitted or empty, all DAGs are optimized. When specified, only BigQuery jobs from matching DAGs are optimized; all others pass through unmodified. Must be a JSON list; any other type is ignored and optimization is skipped as a safe fallback.
 
 ### Setting the Configuration
 

--- a/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
+++ b/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
@@ -107,7 +107,15 @@ def patch_bigquery_hook():
                     except Exception:
                         dag_id = None
 
-                    if dag_id and dag_id not in dag_whitelist:
+                    if dag_id is None:
+                        logging.warning(
+                            "Rabbit BQ Optimizer: dag_whitelist is set but the current "
+                            "DAG could not be determined. Proceeding with original job "
+                            "configuration."
+                        )
+                        return original_insert_job(self, configuration=configuration, **kwargs)
+
+                    if dag_id not in dag_whitelist:
                         logging.debug(
                             "Rabbit BQ Optimizer: DAG '%s' is not in dag_whitelist. "
                             "Skipping optimization.",

--- a/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
+++ b/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
@@ -128,17 +128,28 @@ def _should_optimize_for_current_dag(config: dict[str, Any]) -> bool:
 
     Returns True when optimization should proceed (no whitelist configured, or the
     current DAG is in it). Returns False — leaving the job untouched — when the
-    whitelist is malformed, the current DAG cannot be determined, or the DAG is not
-    listed.
+    whitelist is empty, malformed, the current DAG cannot be determined, or the DAG
+    is not listed.
+
+    An absent (or ``null``) ``dag_whitelist`` means "no restriction" and optimizes
+    every DAG. An explicit empty list means "nothing is whitelisted" and optimizes
+    no DAG.
     """
     dag_whitelist = config.get("dag_whitelist")
-    if not dag_whitelist:
+    if dag_whitelist is None:
         return True
 
     if not isinstance(dag_whitelist, list):
         logging.warning(
             "Rabbit BQ Optimizer: dag_whitelist must be a list, got %s. Using original job.",
             type(dag_whitelist).__name__,
+        )
+        return False
+
+    if not dag_whitelist:
+        logging.info(
+            "Rabbit BQ Optimizer: dag_whitelist is empty; no DAGs are whitelisted. "
+            "Skipping optimization."
         )
         return False
 

--- a/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
+++ b/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
@@ -97,6 +97,24 @@ def patch_bigquery_hook():
                     )
                     return original_insert_job(self, configuration=configuration, **kwargs)
 
+                dag_whitelist = config.get("dag_whitelist")
+                if dag_whitelist:
+                    try:
+                        from airflow.operators.python import get_current_context
+
+                        context = get_current_context()
+                        dag_id = context["dag"].dag_id
+                    except Exception:
+                        dag_id = None
+
+                    if dag_id and dag_id not in dag_whitelist:
+                        logging.debug(
+                            "Rabbit BQ Optimizer: DAG '%s' is not in dag_whitelist. "
+                            "Skipping optimization.",
+                            dag_id,
+                        )
+                        return original_insert_job(self, configuration=configuration, **kwargs)
+
                 logging.debug("Rabbit BQ Optimizer: Original job configuration: %s", configuration)
 
                 try:

--- a/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
+++ b/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
@@ -98,6 +98,14 @@ def patch_bigquery_hook():
                     return original_insert_job(self, configuration=configuration, **kwargs)
 
                 dag_whitelist = config.get("dag_whitelist")
+                if dag_whitelist and not isinstance(dag_whitelist, list):
+                    logging.warning(
+                        "Rabbit BQ Optimizer: dag_whitelist must be a list, got %s. "
+                        "Proceeding with original job configuration.",
+                        type(dag_whitelist).__name__,
+                    )
+                    return original_insert_job(self, configuration=configuration, **kwargs)
+
                 if dag_whitelist:
                     try:
                         from airflow.operators.python import get_current_context
@@ -116,7 +124,7 @@ def patch_bigquery_hook():
                         return original_insert_job(self, configuration=configuration, **kwargs)
 
                     if dag_id not in dag_whitelist:
-                        logging.debug(
+                        logging.info(
                             "Rabbit BQ Optimizer: DAG '%s' is not in dag_whitelist. "
                             "Skipping optimization.",
                             dag_id,

--- a/bq-job-optimizer-airflow-2/test_dag_whitelist.py
+++ b/bq-job-optimizer-airflow-2/test_dag_whitelist.py
@@ -7,7 +7,7 @@ Scenarios covered:
   2. Empty dag_whitelist → all DAGs optimized
   3. DAG in whitelist → optimized
   4. DAG not in whitelist → skipped
-  5. get_current_context unavailable → optimized (safe fallback)
+  5. get_current_context unavailable with whitelist set → skipped (safe fallback)
 """
 
 import os
@@ -161,8 +161,8 @@ def test_dag_not_in_whitelist_skipped():
         return False
 
 
-def test_context_unavailable_falls_through():
-    """If get_current_context fails, optimization should proceed (safe fallback)."""
+def test_context_unavailable_skips_when_whitelist_set():
+    """If dag_whitelist is set but get_current_context fails, optimization should be skipped."""
     config = {**VALID_CONFIG_BASE, "dag_whitelist": ["some_dag"]}
 
     with patch(
@@ -171,13 +171,13 @@ def test_context_unavailable_falls_through():
     ):
         optimized = _run_insert_job(config)
 
-    if optimized:
-        print("✓ Context unavailable → optimization ran (safe fallback)")
+    if not optimized:
+        print("✓ Context unavailable with whitelist → optimization skipped (safe fallback)")
         return True
     else:
         print(
-            "✗ Context unavailable → expected optimization to run as fallback, "
-            "but it was skipped"
+            "✗ Context unavailable with whitelist → expected optimization to be skipped, "
+            "but it ran"
         )
         return False
 
@@ -192,7 +192,7 @@ if __name__ == "__main__":
         test_empty_whitelist_optimizes_all,
         test_dag_in_whitelist_optimized,
         test_dag_not_in_whitelist_skipped,
-        test_context_unavailable_falls_through,
+        test_context_unavailable_skips_when_whitelist_set,
     ]
 
     results = []

--- a/bq-job-optimizer-airflow-2/test_dag_whitelist.py
+++ b/bq-job-optimizer-airflow-2/test_dag_whitelist.py
@@ -4,7 +4,7 @@ Test script that verifies the dag_whitelist feature of the Rabbit BQ Optimizer p
 
 Scenarios covered:
   1. No dag_whitelist → all DAGs optimized (backward compatible)
-  2. Empty dag_whitelist → all DAGs optimized
+  2. Empty dag_whitelist → nothing whitelisted, optimization skipped
   3. DAG in whitelist → optimized
   4. DAG not in whitelist → skipped
   5. get_current_context unavailable with whitelist set → skipped (safe fallback)
@@ -109,16 +109,16 @@ def test_no_whitelist_optimizes_all():
         return False
 
 
-def test_empty_whitelist_optimizes_all():
-    """Empty dag_whitelist should behave the same as absent."""
+def test_empty_whitelist_skips_optimization():
+    """Empty dag_whitelist means nothing is whitelisted, so optimization is skipped."""
     config = {**VALID_CONFIG_BASE, "dag_whitelist": []}
     optimized = _run_insert_job(config)
 
-    if optimized:
-        print("✓ Empty dag_whitelist → optimization ran")
+    if not optimized:
+        print("✓ Empty dag_whitelist → optimization skipped")
         return True
     else:
-        print("✗ Empty dag_whitelist → expected optimization to run, but it didn't")
+        print("✗ Empty dag_whitelist → expected optimization to be skipped, but it ran")
         return False
 
 
@@ -197,7 +197,7 @@ if __name__ == "__main__":
 
     tests = [
         test_no_whitelist_optimizes_all,
-        test_empty_whitelist_optimizes_all,
+        test_empty_whitelist_skips_optimization,
         test_dag_in_whitelist_optimized,
         test_dag_not_in_whitelist_skipped,
         test_context_unavailable_skips_when_whitelist_set,

--- a/bq-job-optimizer-airflow-2/test_dag_whitelist.py
+++ b/bq-job-optimizer-airflow-2/test_dag_whitelist.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Test script that verifies the dag_whitelist feature of the Rabbit BQ Optimizer plugin.
+
+Scenarios covered:
+  1. No dag_whitelist → all DAGs optimized (backward compatible)
+  2. Empty dag_whitelist → all DAGs optimized
+  3. DAG in whitelist → optimized
+  4. DAG not in whitelist → skipped
+  5. get_current_context unavailable → optimized (safe fallback)
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Set up Airflow environment
+script_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.dirname(script_dir)
+os.environ["AIRFLOW_HOME"] = os.path.join(repo_root, "airflow_home")
+sys.path.insert(0, os.path.join(os.environ["AIRFLOW_HOME"], "plugins"))
+
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook, BigQueryJob  # noqa: E402
+
+VALID_CONFIG_BASE = {
+    "default_pricing_mode": "on_demand",
+    "reservation_ids": ["project:us-central1.test-reservation"],
+}
+
+DUMMY_CONNECTION = MagicMock()
+DUMMY_CONNECTION.password = "test-api-key"
+DUMMY_CONNECTION.extra_dejson = {}
+
+
+def _make_mock_optimizer_response():
+    resp = MagicMock()
+    resp.optimizedJob = {"configuration": {"query": {"query": "SELECT 1", "useLegacySql": False}}}
+    return resp
+
+
+def _reset_patch():
+    """Remove the patch marker so patch_bigquery_hook() can be applied again."""
+    if hasattr(BigQueryHook, "_rabbit_bq_job_optimizer_patched"):
+        delattr(BigQueryHook, "_rabbit_bq_job_optimizer_patched")
+
+
+def _run_insert_job(config, context_side_effect=None):
+    """
+    Apply a fresh patch and call insert_job once.
+
+    Returns (optimize_job_called: bool, original_called_with_original: bool).
+    """
+    _reset_patch()
+
+    original_config = {"query": {"query": "SELECT 1", "useLegacySql": False}}
+    original_called_configs = []
+
+    def mock_original(self, *, configuration, **kwargs):
+        original_called_configs.append(configuration)
+        job = MagicMock(spec=BigQueryJob)
+        job.job_id = "test-job-123"
+        return job
+
+    BigQueryHook.insert_job = mock_original
+
+    from rabbit_bq_optimizer_plugin import patch_bigquery_hook
+
+    patch_bigquery_hook()
+
+    mock_client = MagicMock()
+    mock_client.optimize_job.return_value = _make_mock_optimizer_response()
+
+    patches = {
+        "rabbit_bq_optimizer_plugin.Variable.get": MagicMock(return_value=config),
+        "rabbit_bq_optimizer_plugin.BaseHook.get_connection": MagicMock(
+            return_value=DUMMY_CONNECTION
+        ),
+        "rabbit_bq_optimizer_plugin.RabbitBQJobOptimizer": MagicMock(return_value=mock_client),
+    }
+
+    if context_side_effect is not None:
+        patches["rabbit_bq_optimizer_plugin.get_current_context"] = context_side_effect
+
+    with (
+        patch.dict("sys.modules", {}),
+        patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+        patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+        patch(list(patches.keys())[2], patches[list(patches.keys())[2]]),
+    ):
+
+        if len(patches) == 4:
+            ctx_key = list(patches.keys())[3]
+            with patch(ctx_key, patches[ctx_key]):
+                hook = BigQueryHook()
+                hook.insert_job(configuration=original_config)
+        else:
+            hook = BigQueryHook()
+            hook.insert_job(configuration=original_config)
+
+    optimized = mock_client.optimize_job.called
+    return optimized
+
+
+def test_no_whitelist_optimizes_all():
+    """Without dag_whitelist, all DAGs should be optimized."""
+    config = {**VALID_CONFIG_BASE}
+    optimized = _run_insert_job(config)
+
+    if optimized:
+        print("✓ No dag_whitelist → optimization ran")
+        return True
+    else:
+        print("✗ No dag_whitelist → expected optimization to run, but it didn't")
+        return False
+
+
+def test_empty_whitelist_optimizes_all():
+    """Empty dag_whitelist should behave the same as absent."""
+    config = {**VALID_CONFIG_BASE, "dag_whitelist": []}
+    optimized = _run_insert_job(config)
+
+    if optimized:
+        print("✓ Empty dag_whitelist → optimization ran")
+        return True
+    else:
+        print("✗ Empty dag_whitelist → expected optimization to run, but it didn't")
+        return False
+
+
+def test_dag_in_whitelist_optimized():
+    """DAG that appears in the whitelist should be optimized."""
+    config = {**VALID_CONFIG_BASE, "dag_whitelist": ["my_dag", "other_dag"]}
+
+    mock_context = {"dag": MagicMock(dag_id="my_dag")}
+
+    with patch("airflow.operators.python.get_current_context", return_value=mock_context):
+        optimized = _run_insert_job(config)
+
+    if optimized:
+        print("✓ DAG in whitelist → optimization ran")
+        return True
+    else:
+        print("✗ DAG in whitelist → expected optimization to run, but it didn't")
+        return False
+
+
+def test_dag_not_in_whitelist_skipped():
+    """DAG not in the whitelist should skip optimization."""
+    config = {**VALID_CONFIG_BASE, "dag_whitelist": ["allowed_dag"]}
+
+    mock_context = {"dag": MagicMock(dag_id="other_dag")}
+
+    with patch("airflow.operators.python.get_current_context", return_value=mock_context):
+        optimized = _run_insert_job(config)
+
+    if not optimized:
+        print("✓ DAG not in whitelist → optimization skipped")
+        return True
+    else:
+        print("✗ DAG not in whitelist → expected optimization to be skipped, but it ran")
+        return False
+
+
+def test_context_unavailable_falls_through():
+    """If get_current_context fails, optimization should proceed (safe fallback)."""
+    config = {**VALID_CONFIG_BASE, "dag_whitelist": ["some_dag"]}
+
+    with patch(
+        "airflow.operators.python.get_current_context",
+        side_effect=RuntimeError("No context"),
+    ):
+        optimized = _run_insert_job(config)
+
+    if optimized:
+        print("✓ Context unavailable → optimization ran (safe fallback)")
+        return True
+    else:
+        print(
+            "✗ Context unavailable → expected optimization to run as fallback, "
+            "but it was skipped"
+        )
+        return False
+
+
+if __name__ == "__main__":
+    print("=" * 70)
+    print("Rabbit BQ Optimizer Plugin — DAG Whitelist Tests")
+    print("=" * 70)
+
+    tests = [
+        test_no_whitelist_optimizes_all,
+        test_empty_whitelist_optimizes_all,
+        test_dag_in_whitelist_optimized,
+        test_dag_not_in_whitelist_skipped,
+        test_context_unavailable_falls_through,
+    ]
+
+    results = []
+    for test_fn in tests:
+        print(f"\n→ {test_fn.__doc__.strip()}")
+        try:
+            results.append(test_fn())
+        except Exception as e:
+            print(f"✗ {test_fn.__name__} raised an exception: {e}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    passed = sum(results)
+    total = len(results)
+
+    print("\n" + "=" * 70)
+    if all(results):
+        print(f"✓ All {total} dag_whitelist tests PASSED")
+    else:
+        print(f"✗ {total - passed}/{total} dag_whitelist tests FAILED")
+    print("=" * 70)
+
+    sys.exit(0 if all(results) else 1)

--- a/bq-job-optimizer-airflow-2/test_dag_whitelist.py
+++ b/bq-job-optimizer-airflow-2/test_dag_whitelist.py
@@ -8,6 +8,7 @@ Scenarios covered:
   3. DAG in whitelist → optimized
   4. DAG not in whitelist → skipped
   5. get_current_context unavailable with whitelist set → skipped (safe fallback)
+  6. dag_whitelist with wrong type → optimization skipped (safe fallback)
 """
 
 import os
@@ -44,19 +45,20 @@ def _reset_patch():
         delattr(BigQueryHook, "_rabbit_bq_job_optimizer_patched")
 
 
-def _run_insert_job(config, context_side_effect=None):
+def _run_insert_job(config):
     """
     Apply a fresh patch and call insert_job once.
 
-    Returns (optimize_job_called: bool, original_called_with_original: bool).
+    Returns optimize_job_called: bool. Tests that need a specific Airflow
+    context patch ``airflow.operators.python.get_current_context`` themselves
+    before calling this helper, since the plugin imports it locally inside
+    ``insert_job``.
     """
     _reset_patch()
 
     original_config = {"query": {"query": "SELECT 1", "useLegacySql": False}}
-    original_called_configs = []
 
     def mock_original(self, *, configuration, **kwargs):
-        original_called_configs.append(configuration)
         job = MagicMock(spec=BigQueryJob)
         job.job_id = "test-job-123"
         return job
@@ -70,35 +72,21 @@ def _run_insert_job(config, context_side_effect=None):
     mock_client = MagicMock()
     mock_client.optimize_job.return_value = _make_mock_optimizer_response()
 
-    patches = {
-        "rabbit_bq_optimizer_plugin.Variable.get": MagicMock(return_value=config),
-        "rabbit_bq_optimizer_plugin.BaseHook.get_connection": MagicMock(
-            return_value=DUMMY_CONNECTION
-        ),
-        "rabbit_bq_optimizer_plugin.RabbitBQJobOptimizer": MagicMock(return_value=mock_client),
-    }
-
-    if context_side_effect is not None:
-        patches["rabbit_bq_optimizer_plugin.get_current_context"] = context_side_effect
-
     with (
-        patch.dict("sys.modules", {}),
-        patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
-        patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
-        patch(list(patches.keys())[2], patches[list(patches.keys())[2]]),
+        patch("rabbit_bq_optimizer_plugin.Variable.get", return_value=config),
+        patch(
+            "rabbit_bq_optimizer_plugin.BaseHook.get_connection",
+            return_value=DUMMY_CONNECTION,
+        ),
+        patch(
+            "rabbit_bq_optimizer_plugin.RabbitBQJobOptimizer",
+            return_value=mock_client,
+        ),
     ):
+        hook = BigQueryHook()
+        hook.insert_job(configuration=original_config)
 
-        if len(patches) == 4:
-            ctx_key = list(patches.keys())[3]
-            with patch(ctx_key, patches[ctx_key]):
-                hook = BigQueryHook()
-                hook.insert_job(configuration=original_config)
-        else:
-            hook = BigQueryHook()
-            hook.insert_job(configuration=original_config)
-
-    optimized = mock_client.optimize_job.called
-    return optimized
+    return mock_client.optimize_job.called
 
 
 def test_no_whitelist_optimizes_all():
@@ -182,6 +170,19 @@ def test_context_unavailable_skips_when_whitelist_set():
         return False
 
 
+def test_invalid_whitelist_type_skips_optimization():
+    """A dag_whitelist that is not a list should skip optimization (safe fallback)."""
+    config = {**VALID_CONFIG_BASE, "dag_whitelist": "my_dag"}
+    optimized = _run_insert_job(config)
+
+    if not optimized:
+        print("✓ Non-list dag_whitelist → optimization skipped (safe fallback)")
+        return True
+    else:
+        print("✗ Non-list dag_whitelist → expected optimization to be skipped, but it ran")
+        return False
+
+
 if __name__ == "__main__":
     print("=" * 70)
     print("Rabbit BQ Optimizer Plugin — DAG Whitelist Tests")
@@ -193,6 +194,7 @@ if __name__ == "__main__":
         test_dag_in_whitelist_optimized,
         test_dag_not_in_whitelist_skipped,
         test_context_unavailable_skips_when_whitelist_set,
+        test_invalid_whitelist_type_skips_optimization,
     ]
 
     results = []

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="rabbit-bq-optimizer-airflow-plugin",
-    version="1.0.1",
+    version="1.1.0",
     py_modules=["rabbit_bq_optimizer_plugin"],
     package_dir={"": "bq-job-optimizer-airflow-2"},
     install_requires=[

--- a/setup_local_test.sh
+++ b/setup_local_test.sh
@@ -144,6 +144,9 @@ airflow variables set rabbit_bq_optimizer_config '{
     "default_pricing_mode": "on_demand",
     "reservation_ids": [
         "project:us-central1.test-reservation"
+    ],
+    "dag_whitelist": [
+        "rabbit_optimizer_test"
     ]
 }'
 


### PR DESCRIPTION
## Summary

- Adds an optional `dag_whitelist` field to the `rabbit_bq_optimizer_config` Airflow variable
- When omitted or empty, all DAGs are optimized (backward-compatible, no behavior change)
- When set to a list of DAG IDs, only BigQuery jobs from those DAGs are optimized; all others pass through unmodified
- If the Airflow task context is unavailable, optimization proceeds as a safe fallback

## Configuration

```json
{
    "default_pricing_mode": "on_demand",
    "reservation_ids": ["project:region.reservation-name"],
    "dag_whitelist": ["my_etl_dag", "my_analytics_dag"]
}
```

## Changes

- `rabbit_bq_optimizer_plugin.py` — whitelist check using `get_current_context()` after config validation
- `test_dag_whitelist.py` — 5 test scenarios covering all cases (no list, empty list, in list, not in list, context unavailable)
- `ci.yml` — added whitelist test to CI pipeline
- `README.md` — documented `dag_whitelist` field, updated config example and local testing instructions

## Test plan

- [x] All 3 existing test suites pass (connection, DAG execution, whitelist)
- [x] Black + Ruff formatting/linting pass
- [x] Manual local Airflow test: excluded DAG skips optimization, included DAG calls the API
- [ ] CI passes on Python 3.9–3.12

Made with [Cursor](https://cursor.com)