### PR TITLE
feat(plugin): pass project_id + PyPI package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v7
@@ -60,12 +60,12 @@ jobs:
           pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
           pip install -r bq-job-optimizer-airflow-2/test_requirements.txt --constraint "${CONSTRAINT_URL}"
           pip install --constraint "${CONSTRAINT_URL}" google-auth-httplib2 google-api-python-client pandas-gbq gcloud-aio-bigquery gcloud-aio-storage google-cloud-secret-manager google-cloud-storage
+          pip install --constraint "${CONSTRAINT_URL}" -e .
 
       - name: Set up Airflow
         run: |
           export AIRFLOW_HOME=$(pwd)/airflow_home
-          mkdir -p $AIRFLOW_HOME/plugins $AIRFLOW_HOME/dags
-          cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py $AIRFLOW_HOME/plugins/
+          mkdir -p $AIRFLOW_HOME/dags
           cp bq-job-optimizer-airflow-2/test_dag.py $AIRFLOW_HOME/dags/
           airflow db init
           echo -e "admin\nadmin\nAdmin\nUser\nadmin@example.com\n" | airflow users create --username admin --firstname Admin --lastname User --role Admin --email admin@example.com || true
@@ -85,5 +85,12 @@ jobs:
         run: |
           export AIRFLOW_HOME=$(pwd)/airflow_home
           python bq-job-optimizer-airflow-2/test_dag_execution.py
+        env:
+          AIRFLOW_HOME: ${{ github.workspace }}/airflow_home
+
+      - name: Run plugin optimization tests
+        run: |
+          export AIRFLOW_HOME=$(pwd)/airflow_home
+          python -m unittest bq-job-optimizer-airflow-2/test_plugin_optimization.py
         env:
           AIRFLOW_HOME: ${{ github.workspace }}/airflow_home

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to the Rabbit BigQuery Job Optimizer Airflow plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-06-24
+
+### Added
+- PyPI package `rabbit-bq-optimizer-airflow-plugin` with Airflow plugin entry point (no manual copy to `plugins/`).
+- Pass resolved source `project_id` to the optimizer API for pool billing routing.
+
+### Changed
+- Pool billing routing for `BigQueryInsertJobOperator` via operator hook bridge.
+- Empty or missing `reservation_ids` in config defaults to `[]` instead of skipping optimization.

--- a/README.md
+++ b/README.md
@@ -9,4 +9,8 @@ This repository contains the source code for Rabbit's Airflow plugins, specifica
 
 Refer to `bq-job-optimizer-airflow-2/README.md` for installation, configuration, and the end-to-end test plan.
 
+## PyPI
+
+The Airflow 2 plugin is published as [`rabbit-bq-optimizer-airflow-plugin`](https://pypi.org/project/rabbit-bq-optimizer-airflow-plugin/). Release with `./publish_to_pypi.sh` (same flow as the [python-bq-job-optimizer](https://github.com/followrabbit-ai/python-bq-job-optimizer) client).
+
 For more information about Rabbit and our data platform, visit [https://followrabbit.ai/](https://followrabbit.ai/).

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -14,38 +14,59 @@ Already running an older version? See [Updating](#updating).
 
 ## Installation
 
-1. Add the dependency to your Airflow environment:
+Choose **one** of the following — do not use both in the same Airflow environment (duplicate plugin loading).
+
+### Option A: PyPI (recommended)
+
+1. Install the plugin and its dependencies in your Airflow environment:
    - If using `requirements.txt`:
      ```bash
-     echo "rabbit-bq-job-optimizer" >> requirements.txt
+     echo "rabbit-bq-optimizer-airflow-plugin" >> requirements.txt
      pip install -r requirements.txt
      ```
    - If using `constraints.txt`:
      ```bash
-     echo "rabbit-bq-job-optimizer" >> constraints.txt
+     echo "rabbit-bq-optimizer-airflow-plugin" >> constraints.txt
      pip install -r constraints.txt
      ```
    - If using a custom Docker image, add to your Dockerfile:
      ```dockerfile
-     RUN pip install rabbit-bq-job-optimizer
+     RUN pip install rabbit-bq-optimizer-airflow-plugin
      ```
 
-2. Add the plugin to your Airflow plugins directory:
-```bash
-cp rabbit_bq_optimizer_plugin.py $AIRFLOW_HOME/plugins/
-```
+   This installs `rabbit-bq-job-optimizer` (Python client) automatically. The plugin registers via Airflow's plugin entry point — no file copy into `plugins/` is required.
 
-3. Restart your Airflow scheduler, workers, and webserver to load the plugin. If you use deferrable `BigQueryInsertJobOperator`, restart the triggerer as well.
+2. Restart your Airflow scheduler, workers, and webserver to load the plugin. If you use deferrable `BigQueryInsertJobOperator`, restart the triggerer as well.
+
+### Option B: Copy into `plugins/`
+
+1. Install the Python client in your Airflow environment:
+   ```bash
+   pip install rabbit-bq-job-optimizer
+   ```
+
+2. Copy the plugin file into your Airflow plugins directory:
+   ```bash
+   cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py "$AIRFLOW_HOME/plugins/"
+   ```
+
+3. Restart your Airflow scheduler, workers, and webserver (and triggerer if using deferrable operators).
 
 ## Updating
 
-Already running an older version (and want pool billing routing)? Copy the latest `rabbit_bq_optimizer_plugin.py` into your Airflow plugins directory and redeploy:
+Upgrade the PyPI package:
 
 ```bash
-cp rabbit_bq_optimizer_plugin.py $AIRFLOW_HOME/plugins/
+pip install --upgrade rabbit-bq-optimizer-airflow-plugin
 ```
 
 Then restart the scheduler, workers, and webserver (and the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).
+
+If you previously copied `rabbit_bq_optimizer_plugin.py` into `$AIRFLOW_HOME/plugins/` and are switching to the PyPI package, **remove that file** — the PyPI install loads via an entry point and the copied file causes duplicate plugin registration. On startup the plugin logs an error if both are present. To remove the copied file automatically (when writable), set:
+
+```bash
+export RABBIT_BQ_OPTIMIZER_REMOVE_LEGACY_PLUGIN=true
+```
 
 For pool billing routing, the Airflow service account also needs `roles/bigquery.jobUser` on the pool billing projects — contact Rabbit support for your project list. See [Pool billing project routing](#pool-billing-project-routing).
 
@@ -290,7 +311,7 @@ In all error cases, the plugin will log a warning and proceed with the original 
 ## Troubleshooting
 
 ```
-Broken plugin: [/home/airflow/gcs/plugins/rabbit_bq_optimizer_plugin.py] No module named 'rabbit_bq_job_optimizer'
+Broken plugin: `No module named 'rabbit_bq_job_optimizer'` — install `rabbit-bq-optimizer-airflow-plugin` (or `rabbit-bq-job-optimizer`) in the Airflow environment and restart.
 ```
 
 If you see this error, it means the rabbit-bq-job-optimizer package is missing from your Airflow environment. Install it by adding the package (https://pypi.org/project/rabbit-bq-job-optimizer/) to your Airflow requirements or environment.
@@ -342,7 +363,7 @@ The hooks will automatically:
 
 GitHub Actions automatically runs on every push and pull request:
 - **Linting and Formatting**: Checks code style with Black and Ruff
-- **Tests**: Runs test suite on Python 3.9, 3.10, 3.11, and 3.12
+- **Tests**: Runs test suite on Python 3.10, 3.11, and 3.12
 
 ## Uninstalling
 

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -18,39 +18,34 @@ Choose **one** of the following — do not use both in the same Airflow environm
 
 ### Option A: PyPI (recommended)
 
-Add **both** dependencies to your Airflow environment (managed environments such as Composer install from `requirements.txt` — you do not `pip install` on running workers):
+1. Add the plugin and client to your Airflow environment:
+   - If using `requirements.txt`:
+     ```bash
+     echo "rabbit-bq-job-optimizer==0.1.18" >> requirements.txt
+     echo "rabbit-bq-optimizer-airflow-plugin==1.0.0" >> requirements.txt
+     pip install -r requirements.txt
+     ```
+   - If using `constraints.txt`:
+     ```bash
+     echo "rabbit-bq-job-optimizer==0.1.18" >> constraints.txt
+     echo "rabbit-bq-optimizer-airflow-plugin==1.0.0" >> constraints.txt
+     pip install -r constraints.txt
+     ```
+   - If using a custom Docker image, add to your Dockerfile:
+     ```dockerfile
+     RUN pip install rabbit-bq-job-optimizer==0.1.18 rabbit-bq-optimizer-airflow-plugin==1.0.0
+     ```
 
-```txt
-rabbit-bq-job-optimizer>=0.1.17
-rabbit-bq-optimizer-airflow-plugin>=1.0.0
-```
+   The plugin registers via Airflow's plugin entry point — no file copy into `plugins/` is required.
 
-Pin exact versions if your environment requires it:
-
-```txt
-rabbit-bq-job-optimizer==0.1.17
-rabbit-bq-optimizer-airflow-plugin==1.0.0
-```
-
-How you apply that depends on your setup:
-
-- **`requirements.txt`** (Composer, MWAA, custom images): add the lines above, then update/rebuild the environment so packages are installed on scheduler, workers, and webserver.
-- **`constraints.txt`**: add the same package lines to your constraints or requirements file used at image build time.
-- **Dockerfile**:
-  ```dockerfile
-  RUN pip install "rabbit-bq-job-optimizer>=0.1.17" "rabbit-bq-optimizer-airflow-plugin>=1.0.0"
-  ```
-
-The plugin registers via Airflow's plugin entry point — no file copy into `plugins/` is required. Listing the client explicitly keeps your `requirements.txt` self-contained and makes version upgrades visible alongside the plugin.
-
-Restart your Airflow scheduler, workers, and webserver after the environment update. If you use deferrable `BigQueryInsertJobOperator`, restart the triggerer as well.
+2. Restart your Airflow scheduler, workers, and webserver to load the plugin. If you use deferrable `BigQueryInsertJobOperator`, restart the triggerer as well.
 
 ### Option B: Copy into `plugins/`
 
 1. Add the Python client to your Airflow environment `requirements.txt` (or equivalent):
 
    ```txt
-   rabbit-bq-job-optimizer>=0.1.17
+   rabbit-bq-job-optimizer==0.1.18
    ```
 
 2. Copy the plugin file into your Airflow plugins directory (Composer: plugins bucket; self-managed: `$AIRFLOW_HOME/plugins/`):
@@ -68,8 +63,8 @@ Restart your Airflow scheduler, workers, and webserver after the environment upd
 Bump versions in `requirements.txt` (or your environment's package list), then update/rebuild the environment:
 
 ```txt
-rabbit-bq-job-optimizer>=0.1.17
-rabbit-bq-optimizer-airflow-plugin>=1.0.0
+rabbit-bq-job-optimizer==0.1.18
+rabbit-bq-optimizer-airflow-plugin==1.0.0
 ```
 
 Then restart the scheduler, workers, and webserver (and the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).
@@ -79,7 +74,7 @@ Then restart the scheduler, workers, and webserver (and the triggerer if you use
 If you installed via [Option B](#option-b-copy-into-plugins) and want to stay on the copy method, replace the file in your plugins directory with the new version from this repo, then restart Airflow:
 
 ```bash
-pip install --upgrade rabbit-bq-job-optimizer
+pip install --upgrade rabbit-bq-job-optimizer==0.1.18
 cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py "$AIRFLOW_HOME/plugins/"
 ```
 

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -14,20 +14,27 @@ Already running an older version? See [Updating](#updating).
 
 ## Installation
 
-Choose **one** of the following — do not use both in the same Airflow environment (duplicate plugin loading).
-
 ### Option A: PyPI (recommended)
 
-1. Add both packages to your Airflow environment dependencies (for example `requirements.txt`, Composer PyPI packages, or a custom image build):
-
-   ```txt
-   rabbit-bq-job-optimizer==0.1.18
-   rabbit-bq-optimizer-airflow-plugin==1.0.0
-   ```
+1. Add the plugin and client to your Airflow environment:
+   - If using `requirements.txt`:
+     ```txt
+     rabbit-bq-job-optimizer==0.1.18
+     rabbit-bq-optimizer-airflow-plugin==1.0.0
+     ```
+   - If using `constraints.txt`:
+     ```txt
+     rabbit-bq-job-optimizer==0.1.18
+     rabbit-bq-optimizer-airflow-plugin==1.0.0
+     ```
+   - If using a custom Docker image, add to your Dockerfile:
+     ```dockerfile
+     RUN pip install rabbit-bq-job-optimizer==0.1.18 rabbit-bq-optimizer-airflow-plugin==1.0.0
+     ```
 
    The plugin registers via Airflow's plugin entry point — no file copy into `plugins/` is required.
 
-2. Apply the dependency update using your platform's usual process, then restart Airflow components so the plugin loads (scheduler, workers, webserver, and triggerer if you use deferrable `BigQueryInsertJobOperator`).
+2. Restart your Airflow scheduler, workers, and webserver to load the plugin. If you use deferrable `BigQueryInsertJobOperator`, restart the triggerer as well.
 
 ### Option B: Copy into `plugins/`
 
@@ -37,9 +44,12 @@ Choose **one** of the following — do not use both in the same Airflow environm
    rabbit-bq-job-optimizer==0.1.18
    ```
 
-2. Deploy `rabbit_bq_optimizer_plugin.py` from this repo to your environment's Airflow plugins location.
+2. Copy the plugin file into your Airflow plugins directory:
+   ```bash
+   cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py "$AIRFLOW_HOME/plugins/"
+   ```
 
-3. Apply the dependency update and plugin deploy using your platform's usual process, then restart Airflow components (including the triggerer if you use deferrable operators).
+3. Restart your Airflow scheduler, workers, and webserver (and triggerer if using deferrable operators).
 
 ## Updating
 

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -18,34 +18,43 @@ Choose **one** of the following — do not use both in the same Airflow environm
 
 ### Option A: PyPI (recommended)
 
-1. Install the plugin and its dependencies in your Airflow environment:
-   - If using `requirements.txt`:
-     ```bash
-     echo "rabbit-bq-optimizer-airflow-plugin" >> requirements.txt
-     pip install -r requirements.txt
-     ```
-   - If using `constraints.txt`:
-     ```bash
-     echo "rabbit-bq-optimizer-airflow-plugin" >> constraints.txt
-     pip install -r constraints.txt
-     ```
-   - If using a custom Docker image, add to your Dockerfile:
-     ```dockerfile
-     RUN pip install rabbit-bq-optimizer-airflow-plugin
-     ```
+Add **both** dependencies to your Airflow environment (managed environments such as Composer install from `requirements.txt` — you do not `pip install` on running workers):
 
-   This installs `rabbit-bq-job-optimizer` (Python client) automatically. The plugin registers via Airflow's plugin entry point — no file copy into `plugins/` is required.
+```txt
+rabbit-bq-job-optimizer>=0.1.17
+rabbit-bq-optimizer-airflow-plugin>=1.0.0
+```
 
-2. Restart your Airflow scheduler, workers, and webserver to load the plugin. If you use deferrable `BigQueryInsertJobOperator`, restart the triggerer as well.
+Pin exact versions if your environment requires it:
+
+```txt
+rabbit-bq-job-optimizer==0.1.17
+rabbit-bq-optimizer-airflow-plugin==1.0.0
+```
+
+How you apply that depends on your setup:
+
+- **`requirements.txt`** (Composer, MWAA, custom images): add the lines above, then update/rebuild the environment so packages are installed on scheduler, workers, and webserver.
+- **`constraints.txt`**: add the same package lines to your constraints or requirements file used at image build time.
+- **Dockerfile**:
+  ```dockerfile
+  RUN pip install "rabbit-bq-job-optimizer>=0.1.17" "rabbit-bq-optimizer-airflow-plugin>=1.0.0"
+  ```
+
+The plugin registers via Airflow's plugin entry point — no file copy into `plugins/` is required. Listing the client explicitly keeps your `requirements.txt` self-contained and makes version upgrades visible alongside the plugin.
+
+Restart your Airflow scheduler, workers, and webserver after the environment update. If you use deferrable `BigQueryInsertJobOperator`, restart the triggerer as well.
 
 ### Option B: Copy into `plugins/`
 
-1. Install the Python client in your Airflow environment:
-   ```bash
-   pip install rabbit-bq-job-optimizer
+1. Add the Python client to your Airflow environment `requirements.txt` (or equivalent):
+
+   ```txt
+   rabbit-bq-job-optimizer>=0.1.17
    ```
 
-2. Copy the plugin file into your Airflow plugins directory:
+2. Copy the plugin file into your Airflow plugins directory (Composer: plugins bucket; self-managed: `$AIRFLOW_HOME/plugins/`):
+
    ```bash
    cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py "$AIRFLOW_HOME/plugins/"
    ```
@@ -56,10 +65,11 @@ Choose **one** of the following — do not use both in the same Airflow environm
 
 ### PyPI install
 
-Upgrade the package:
+Bump versions in `requirements.txt` (or your environment's package list), then update/rebuild the environment:
 
-```bash
-pip install --upgrade rabbit-bq-optimizer-airflow-plugin
+```txt
+rabbit-bq-job-optimizer>=0.1.17
+rabbit-bq-optimizer-airflow-plugin>=1.0.0
 ```
 
 Then restart the scheduler, workers, and webserver (and the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -18,75 +18,49 @@ Choose **one** of the following — do not use both in the same Airflow environm
 
 ### Option A: PyPI (recommended)
 
-1. Add the plugin and client to your Airflow environment:
-   - If using `requirements.txt`:
-     ```bash
-     echo "rabbit-bq-job-optimizer==0.1.18" >> requirements.txt
-     echo "rabbit-bq-optimizer-airflow-plugin==1.0.0" >> requirements.txt
-     pip install -r requirements.txt
-     ```
-   - If using `constraints.txt`:
-     ```bash
-     echo "rabbit-bq-job-optimizer==0.1.18" >> constraints.txt
-     echo "rabbit-bq-optimizer-airflow-plugin==1.0.0" >> constraints.txt
-     pip install -r constraints.txt
-     ```
-   - If using a custom Docker image, add to your Dockerfile:
-     ```dockerfile
-     RUN pip install rabbit-bq-job-optimizer==0.1.18 rabbit-bq-optimizer-airflow-plugin==1.0.0
-     ```
+1. Add both packages to your Airflow environment dependencies (for example `requirements.txt`, Composer PyPI packages, or a custom image build):
+
+   ```txt
+   rabbit-bq-job-optimizer==0.1.18
+   rabbit-bq-optimizer-airflow-plugin==1.0.0
+   ```
 
    The plugin registers via Airflow's plugin entry point — no file copy into `plugins/` is required.
 
-2. Restart your Airflow scheduler, workers, and webserver to load the plugin. If you use deferrable `BigQueryInsertJobOperator`, restart the triggerer as well.
+2. Apply the dependency update using your platform's usual process, then restart Airflow components so the plugin loads (scheduler, workers, webserver, and triggerer if you use deferrable `BigQueryInsertJobOperator`).
 
 ### Option B: Copy into `plugins/`
 
-1. Add the Python client to your Airflow environment `requirements.txt` (or equivalent):
+1. Add the Python client to your Airflow environment dependencies:
 
    ```txt
    rabbit-bq-job-optimizer==0.1.18
    ```
 
-2. Copy the plugin file into your Airflow plugins directory (Composer: plugins bucket; self-managed: `$AIRFLOW_HOME/plugins/`):
+2. Deploy `rabbit_bq_optimizer_plugin.py` from this repo to your environment's Airflow plugins location.
 
-   ```bash
-   cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py "$AIRFLOW_HOME/plugins/"
-   ```
-
-3. Restart your Airflow scheduler, workers, and webserver (and triggerer if using deferrable operators).
+3. Apply the dependency update and plugin deploy using your platform's usual process, then restart Airflow components (including the triggerer if you use deferrable operators).
 
 ## Updating
 
 ### PyPI install
 
-Bump versions in `requirements.txt` (or your environment's package list), then update/rebuild the environment:
+Update to the new package versions in your environment dependencies:
 
 ```txt
 rabbit-bq-job-optimizer==0.1.18
 rabbit-bq-optimizer-airflow-plugin==1.0.0
 ```
 
-Then restart the scheduler, workers, and webserver (and the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).
+Apply the update using your platform's usual process, then restart Airflow components (including the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).
 
 ### Copy into `plugins/` (optional)
 
-If you installed via [Option B](#option-b-copy-into-plugins) and want to stay on the copy method, replace the file in your plugins directory with the new version from this repo, then restart Airflow:
-
-```bash
-pip install --upgrade rabbit-bq-job-optimizer==0.1.18
-cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py "$AIRFLOW_HOME/plugins/"
-```
-
-Then restart the scheduler, workers, and webserver (and the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).
+If you installed via [Option B](#option-b-copy-into-plugins) and want to stay on the copy method, bump the client version in your environment dependencies and replace `rabbit_bq_optimizer_plugin.py` in your plugins location with the new file from this repo. Then restart Airflow components as above.
 
 ### Switching from copy to PyPI
 
-If you previously copied `rabbit_bq_optimizer_plugin.py` into `$AIRFLOW_HOME/plugins/` and are switching to the PyPI package, **remove that file** — the PyPI install loads via an entry point and the copied file causes duplicate plugin registration. On startup the plugin logs an error if both are present. To remove the copied file automatically (when writable), set:
-
-```bash
-export RABBIT_BQ_OPTIMIZER_REMOVE_LEGACY_PLUGIN=true
-```
+If you previously deployed `rabbit_bq_optimizer_plugin.py` to your plugins location and are switching to the PyPI package, **remove that file** — the PyPI install loads via an entry point and the copied file causes duplicate plugin registration. On startup the plugin logs an error if both are present. When the file is writable, you can set `RABBIT_BQ_OPTIMIZER_REMOVE_LEGACY_PLUGIN=true` to remove it automatically on load.
 
 For pool billing routing, the Airflow service account also needs `roles/bigquery.jobUser` on the pool billing projects — contact Rabbit support for your project list. See [Pool billing project routing](#pool-billing-project-routing).
 

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -54,13 +54,28 @@ Choose **one** of the following — do not use both in the same Airflow environm
 
 ## Updating
 
-Upgrade the PyPI package:
+### PyPI install
+
+Upgrade the package:
 
 ```bash
 pip install --upgrade rabbit-bq-optimizer-airflow-plugin
 ```
 
 Then restart the scheduler, workers, and webserver (and the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).
+
+### Copy into `plugins/` (optional)
+
+If you installed via [Option B](#option-b-copy-into-plugins) and want to stay on the copy method, replace the file in your plugins directory with the new version from this repo, then restart Airflow:
+
+```bash
+pip install --upgrade rabbit-bq-job-optimizer
+cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py "$AIRFLOW_HOME/plugins/"
+```
+
+Then restart the scheduler, workers, and webserver (and the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).
+
+### Switching from copy to PyPI
 
 If you previously copied `rabbit_bq_optimizer_plugin.py` into `$AIRFLOW_HOME/plugins/` and are switching to the PyPI package, **remove that file** — the PyPI install loads via an entry point and the copied file causes duplicate plugin registration. On startup the plugin logs an error if both are present. To remove the copied file automatically (when writable), set:
 

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -378,7 +378,7 @@ The hooks will automatically:
 
 GitHub Actions automatically runs on every push and pull request:
 - **Linting and Formatting**: Checks code style with Black and Ruff
-- **Tests**: Runs test suite on Python 3.10, 3.11, and 3.12
+- **Tests**: Runs test suite on Python 3.9, 3.10, 3.11, and 3.12
 
 ## Uninstalling
 

--- a/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
+++ b/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
@@ -91,7 +91,13 @@ def _load_optimizer_config() -> dict[str, Any] | None:
         return None
 
     config = dict(config)
-    config["reservation_ids"] = config.get("reservation_ids") or []
+    reservation_ids = config.get("reservation_ids") or []
+    if config["default_pricing_mode"] == "on_demand" and not reservation_ids:
+        logging.warning(
+            "Rabbit BQ Optimizer: on_demand default with no reservation_ids. " "Using original job."
+        )
+        return None
+    config["reservation_ids"] = reservation_ids
     return config
 
 
@@ -123,19 +129,23 @@ def _optimize(
         client_kwargs["base_url"] = credentials["base_url"]
     client = RabbitBQJobOptimizer(**client_kwargs)
 
+    optimize_kwargs: dict[str, Any] = {
+        "configuration": {"configuration": configuration},
+        "enabledOptimizations": [
+            OptimizationConfig(
+                type="reservation_assignment",
+                config={
+                    "defaultPricingMode": config.get("default_pricing_mode"),
+                    "reservationIds": config["reservation_ids"],
+                },
+            )
+        ],
+    }
+    if source_project:
+        optimize_kwargs["project_id"] = source_project
+
     try:
-        result = client.optimize_job(
-            configuration={"configuration": configuration},
-            enabledOptimizations=[
-                OptimizationConfig(
-                    type="reservation_assignment",
-                    config={
-                        "defaultPricingMode": config.get("default_pricing_mode"),
-                        "reservationIds": config["reservation_ids"],
-                    },
-                )
-            ],
-        )
+        result = client.optimize_job(**optimize_kwargs)
     except Exception as exc:
         logging.warning("Rabbit BQ Optimizer: optimize_job failed: %s. Using original job.", exc)
         return None
@@ -241,9 +251,54 @@ def patch_bigquery_hook() -> None:
     BigQueryHook.insert_job = patched_insert_job
 
 
+LEGACY_PLUGIN_FILENAME = "rabbit_bq_optimizer_plugin.py"
+
+
+def _warn_or_remove_legacy_plugin_file() -> None:
+    """Drop the pre-PyPI copy-to-plugins deploy file when upgrading."""
+    airflow_home = os.environ.get("AIRFLOW_HOME")
+    if not airflow_home:
+        return
+
+    legacy = os.path.join(airflow_home, "plugins", LEGACY_PLUGIN_FILENAME)
+    if not os.path.isfile(legacy):
+        return
+
+    msg = (
+        "Rabbit BQ Optimizer: found legacy plugin file at %s. "
+        "Remove it when using rabbit-bq-optimizer-airflow-plugin from PyPI "
+        "to avoid duplicate plugin loading."
+    )
+    auto_remove = os.environ.get("RABBIT_BQ_OPTIMIZER_REMOVE_LEGACY_PLUGIN", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if auto_remove:
+        try:
+            os.remove(legacy)
+            logging.warning(
+                "Rabbit BQ Optimizer: removed legacy plugin file %s "
+                "(RABBIT_BQ_OPTIMIZER_REMOVE_LEGACY_PLUGIN enabled).",
+                legacy,
+            )
+        except OSError as exc:
+            logging.error(
+                "Rabbit BQ Optimizer: could not remove legacy plugin file %s: %s",
+                legacy,
+                exc,
+            )
+    else:
+        logging.error(
+            "%s Set env RABBIT_BQ_OPTIMIZER_REMOVE_LEGACY_PLUGIN=true to remove automatically.",
+            msg % legacy,
+        )
+
+
 class RabbitBQOptimizerPlugin(AirflowPlugin, LoggingMixin):
     name = "rabbit_bq_job_optimizer_plugin"
 
     def on_load(self, *args, **kwargs):
+        _warn_or_remove_legacy_plugin_file()
         patch_bigquery_hook()
         patch_bigquery_insert_job_operator()

--- a/bq-job-optimizer-airflow-2/test_dag_execution.py
+++ b/bq-job-optimizer-airflow-2/test_dag_execution.py
@@ -14,7 +14,6 @@ from unittest.mock import MagicMock, patch
 script_dir = os.path.dirname(os.path.abspath(__file__))
 repo_root = os.path.dirname(script_dir)
 os.environ["AIRFLOW_HOME"] = os.path.join(repo_root, "airflow_home")
-sys.path.insert(0, os.path.join(os.environ["AIRFLOW_HOME"], "plugins"))
 
 # Import Airflow components
 from airflow.hooks.base import BaseHook  # noqa: E402

--- a/bq-job-optimizer-airflow-2/test_plugin_connection.py
+++ b/bq-job-optimizer-airflow-2/test_plugin_connection.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock, patch
 script_dir = os.path.dirname(os.path.abspath(__file__))
 repo_root = os.path.dirname(script_dir)
 os.environ["AIRFLOW_HOME"] = os.path.join(repo_root, "airflow_home")
-sys.path.insert(0, os.path.join(os.environ["AIRFLOW_HOME"], "plugins"))
 
 # Import Airflow components
 from airflow.exceptions import AirflowException  # noqa: E402

--- a/bq-job-optimizer-airflow-2/test_plugin_optimization.py
+++ b/bq-job-optimizer-airflow-2/test_plugin_optimization.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import unittest
 from contextlib import contextmanager
 from datetime import datetime
@@ -13,7 +12,6 @@ from unittest.mock import MagicMock, patch
 script_dir = os.path.dirname(os.path.abspath(__file__))
 repo_root = os.path.dirname(script_dir)
 os.environ.setdefault("AIRFLOW_HOME", os.path.join(repo_root, "airflow_home"))
-sys.path.insert(0, os.path.join(os.environ["AIRFLOW_HOME"], "plugins"))
 
 # Generic example GCP project IDs — no customer-specific names in public tests.
 SOURCE_PROJECT = "example-analytics-prod"
@@ -110,7 +108,7 @@ class TestPluginOptimization(unittest.TestCase):
         self.assertEqual(labels.get("rabbit-pool-project"), POOL_BILLING_PROJECT)
         self.assertEqual(labels.get("rabbit-pool-routing"), "skipped")
         payload = mock_client.optimize_job.call_args.kwargs
-        self.assertNotIn("project_id", payload)
+        self.assertEqual(payload.get("project_id"), SOURCE_PROJECT)
 
     def test_insert_job_operator_routes_billing_project(self):
         import importlib
@@ -170,6 +168,9 @@ class TestPluginOptimization(unittest.TestCase):
         labels = submitted["configuration"].get("labels", {})
         self.assertEqual(labels.get("rabbit-pool-project"), POOL_BILLING_PROJECT)
         self.assertEqual(labels.get("rabbit-pool-routing"), "applied")
+        self.assertEqual(
+            mock_client.optimize_job.call_args.kwargs.get("project_id"), SOURCE_PROJECT
+        )
 
     def test_operator_failopen_restores_source_project(self):
         """If the pool submit fails, fail-open must reset operator.project_id to the source."""
@@ -287,7 +288,51 @@ class TestPluginOptimization(unittest.TestCase):
         self.assertNotIn("rabbit-pool-project", labels)
         mock_client.optimize_job.assert_called_once()
 
-    def test_missing_reservation_ids_calls_optimizer_with_empty_list(self):
+    def test_on_demand_missing_reservation_ids_skips_optimizer(self):
+        import importlib
+
+        import rabbit_bq_optimizer_plugin as plugin_module
+        from airflow.models import Variable
+        from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+
+        importlib.reload(plugin_module)
+
+        original_config = {"query": {"query": "SELECT 1", "useLegacySql": False}}
+        submitted: dict = {}
+
+        def fake_bq_submit(self, *, configuration, **kwargs):
+            submitted["configuration"] = configuration
+            return MagicMock(job_id="mock-job-empty-res")
+
+        BigQueryHook.insert_job = fake_bq_submit
+
+        mock_client = MagicMock()
+
+        with (
+            patch.object(
+                Variable,
+                "get",
+                return_value={"default_pricing_mode": "on_demand"},
+            ),
+            patch.object(
+                plugin_module,
+                "_load_rabbit_credentials",
+                return_value={"api_key": "k", "base_url": None},
+            ),
+            patch.object(plugin_module, "RabbitBQJobOptimizer", return_value=mock_client),
+        ):
+            plugin_module.patch_bigquery_hook()
+
+            hook = BigQueryHook(gcp_conn_id="google_cloud_default")
+            hook.insert_job(
+                configuration=dict(original_config),
+                project_id=SOURCE_PROJECT,
+            )
+
+        mock_client.optimize_job.assert_not_called()
+        self.assertEqual(submitted["configuration"], original_config)
+
+    def test_slot_based_missing_reservation_ids_calls_optimizer_with_empty_list(self):
         import importlib
 
         import rabbit_bq_optimizer_plugin as plugin_module
@@ -297,7 +342,7 @@ class TestPluginOptimization(unittest.TestCase):
         importlib.reload(plugin_module)
 
         def fake_bq_submit(self, *, configuration, **kwargs):
-            return MagicMock(job_id="mock-job-empty-res")
+            return MagicMock(job_id="mock-job-slot-empty-res")
 
         BigQueryHook.insert_job = fake_bq_submit
 
@@ -308,7 +353,7 @@ class TestPluginOptimization(unittest.TestCase):
             patch.object(
                 Variable,
                 "get",
-                return_value={"default_pricing_mode": "on_demand"},
+                return_value={"default_pricing_mode": "slot_based"},
             ),
             patch.object(
                 plugin_module,

--- a/bq-job-optimizer-airflow-2/test_requirements.txt
+++ b/bq-job-optimizer-airflow-2/test_requirements.txt
@@ -1,3 +1,2 @@
-rabbit-bq-job-optimizer
 apache-airflow-providers-google
 google-cloud-bigquery

--- a/publish_to_pypi.sh
+++ b/publish_to_pypi.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+echo "🚀 Starting package publication process..."
+
+# Create and activate virtual environment if not exists
+if [ ! -d "venv" ]; then
+    echo "📦 Creating new virtual environment..."
+    python3 -m venv venv
+else
+    echo "📦 Using existing virtual environment..."
+fi
+source venv/bin/activate
+
+# Install required tools
+echo "🔧 Installing required tools..."
+pip install twine setuptools
+
+# Get version from setup.py
+VERSION=$(python -c "import re; print(re.search(r'version=\"([^\"]+)\"', open('setup.py').read()).group(1))")
+echo "📝 Current version: $VERSION"
+
+# Clean dist folder
+echo "🧹 Cleaning dist folder..."
+rm -rf dist/*
+
+# Build the package
+echo "🏗️  Building package..."
+python setup.py sdist bdist_wheel
+
+# Create git tag
+echo "🏷️  Creating git tag v$VERSION..."
+git tag -a "v$VERSION" -m "Release version $VERSION"
+git push origin "v$VERSION"
+
+# Upload the package to PyPI
+echo "📤 Uploading package to PyPI..."
+twine upload dist/*
+
+# Increment version
+IFS='.' read -ra VERSION_PARTS <<< "$VERSION"
+NEW_PATCH=$((VERSION_PARTS[2] + 1))
+NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$NEW_PATCH"
+echo "📈 Incrementing version to $NEW_VERSION..."
+sed -i '' "s/version=\"$VERSION\"/version=\"$NEW_VERSION\"/" setup.py
+
+# Deactivate virtual environment
+echo "👋 Deactivating virtual environment..."
+deactivate
+
+echo "✅ Publication process completed successfully!"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "Operating System :: OS Independent",
         "Framework :: Apache Airflow",
     ],
-    python_requires=">=3.10",
+    python_requires=">=3.8",
     entry_points={
         "airflow.plugins": [
             "rabbit_bq_job_optimizer_plugin = "

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+from setuptools import setup
+
+setup(
+    name="rabbit-bq-optimizer-airflow-plugin",
+    version="1.0.0",
+    py_modules=["rabbit_bq_optimizer_plugin"],
+    package_dir={"": "bq-job-optimizer-airflow-2"},
+    install_requires=[
+        "rabbit-bq-job-optimizer>=0.1.17",
+    ],
+    author="Rabbit Team",
+    author_email="success@followrabbit.ai",
+    description="Airflow 2 plugin for Rabbit BigQuery Job Optimizer",
+    long_description=open("bq-job-optimizer-airflow-2/README.md").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/followrabbit-ai/bq-job-optimizer-airflow-plugin",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Framework :: Apache Airflow",
+    ],
+    python_requires=">=3.10",
+    entry_points={
+        "airflow.plugins": [
+            "rabbit_bq_job_optimizer_plugin = "
+            "rabbit_bq_optimizer_plugin:RabbitBQOptimizerPlugin",
+        ],
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     py_modules=["rabbit_bq_optimizer_plugin"],
     package_dir={"": "bq-job-optimizer-airflow-2"},
     install_requires=[
-        "rabbit-bq-job-optimizer>=0.1.17",
+        "rabbit-bq-job-optimizer>=0.1.18",
     ],
     author="Rabbit Team",
     author_email="success@followrabbit.ai",

--- a/setup_local_test.sh
+++ b/setup_local_test.sh
@@ -102,6 +102,7 @@ pip install --constraint "${CONSTRAINT_URL}" \
     gcloud-aio-storage \
     google-cloud-secret-manager \
     google-cloud-storage
+pip install --constraint "${CONSTRAINT_URL}" -e .
 
 # Initialize Airflow DB
 if [ ! -f "$AIRFLOW_HOME/airflow.db" ]; then
@@ -118,10 +119,9 @@ if [ ! -f "$AIRFLOW_HOME/airflow.db" ]; then
         --password admin
 fi
 
-# Copy plugin and test DAG
-echo "Deploying plugin..."
-cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py "$PLUGIN_DIR/"
-
+# Deploy test DAG (plugin loads via pip install -e . entry point)
+# For copy-paste testing instead, comment out `pip install -e .` above and run:
+#   cp bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py "$PLUGIN_DIR/"
 echo "Deploying test DAG..."
 cp bq-job-optimizer-airflow-2/test_dag.py "$DAGS_DIR/"
 


### PR DESCRIPTION
## Summary
- Pass resolved source `project_id` to `optimize_job()` so the optimizer API receives `projectId` for attribution and pool routing.
- Package the plugin as `rabbit-bq-optimizer-airflow-plugin` on PyPI (same release flow as `python-bq-job-optimizer`: `setup.py`, entry point, `publish_to_pypi.sh`).

## Merge order
1. Merge and publish `rabbit-bq-job-optimizer` **0.1.18** (client PR #10)
2. Merge this PR and run `./publish_to_pypi.sh` for plugin **1.0.0**

## Test plan
- [ ] CI green (installs client from GitHub master until 0.1.18 is on PyPI)
- [ ] `pip install -e .` in local Airflow env; plugin loads via entry point
- [ ] Pool routing e2e on Composer after publish