### PR TITLE
Add enabled gate on rabbit_bq_optimizer_config (v1.0.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           airflow db init
           echo -e "admin\nadmin\nAdmin\nUser\nadmin@example.com\n" | airflow users create --username admin --firstname Admin --lastname User --role Admin --email admin@example.com || true
           airflow connections add rabbit_api --conn-type generic --conn-password "test-key" --conn-extra '{"api_base_url": "https://api.followrabbit.ai/bq-job-optimizer"}' || true
-          airflow variables set rabbit_bq_optimizer_config '{"default_pricing_mode": "on_demand", "reservation_ids": ["project:us-central1.test-reservation"]}' || true
+          airflow variables set rabbit_bq_optimizer_config '{"enabled": true, "default_pricing_mode": "on_demand", "reservation_ids": ["project:us-central1.test-reservation"]}' || true
         env:
           AIRFLOW_HOME: ${{ github.workspace }}/airflow_home
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-26
+
+### Added
+- `enabled` field on `rabbit_bq_optimizer_config` — set to `false` to skip optimization entirely (no API call). Defaults to `true` when omitted. Checked at the hook boundary before each optimize call (no restart required).
+
 ## [1.0.0] - 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.1] - 2026-06-26
 
 ### Added
-- `enabled` field on `rabbit_bq_optimizer_config` — set to `false` to skip optimization entirely (no API call). Defaults to `true` when omitted. Checked at the hook boundary before each optimize call (no restart required).
+- `enabled` field on `rabbit_bq_optimizer_config` — optimization runs only when `"enabled": true` is set explicitly; otherwise jobs bypass the optimizer (no API call). Checked at the hook boundary before each optimize call (no restart required).
 
 ## [1.0.0] - 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the source code for Rabbit's Airflow plugins, specifica
 - Patches the BigQuery hook to transparently send job configurations to the Rabbit Job Optimizer service.
 - Authenticates via the official `rabbit-bq-job-optimizer` Python client (install the latest version for compatibility).
 - Retrieves the Rabbit API key (and optional base URL override) from the Airflow connection `rabbit_api` so secrets stay out of plain-text variables.
-- Reads optimization parameters (pricing mode, reservation IDs, etc.) from the `rabbit_bq_optimizer_config` Airflow variable. Set `"enabled": false` in that JSON (or omit the variable entirely) to leave BigQuery jobs unchanged on each submit.
+- Reads optimization parameters (pricing mode, reservation IDs, etc.) from the `rabbit_bq_optimizer_config` Airflow variable. Optimization runs only when `"enabled": true` is set explicitly; otherwise BigQuery jobs are unchanged on each submit.
 
 Refer to `bq-job-optimizer-airflow-2/README.md` for installation, configuration, and the end-to-end test plan.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the source code for Rabbit's Airflow plugins, specifica
 - Patches the BigQuery hook to transparently send job configurations to the Rabbit Job Optimizer service.
 - Authenticates via the official `rabbit-bq-job-optimizer` Python client (install the latest version for compatibility).
 - Retrieves the Rabbit API key (and optional base URL override) from the Airflow connection `rabbit_api` so secrets stay out of plain-text variables.
-- Reads optimization parameters (pricing mode, reservation IDs, etc.) from the `rabbit_bq_optimizer_config` Airflow variable.
+- Reads optimization parameters (pricing mode, reservation IDs, etc.) from the `rabbit_bq_optimizer_config` Airflow variable. Set `"enabled": false` in that JSON (or omit the variable entirely) to leave BigQuery jobs unchanged on each submit.
 
 Refer to `bq-job-optimizer-airflow-2/README.md` for installation, configuration, and the end-to-end test plan.
 

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -117,9 +117,9 @@ The remaining optimizer configuration stays in an Airflow variable. Create a JSO
 
 ### Configuration Fields
 
-- `enabled` (optional, default `true`): When `false`, or when the variable is not set, each BigQuery submit bypasses optimization (no API call). Takes effect on the next job without restarting Airflow.
-- `default_pricing_mode` (required when enabled): The default pricing mode for jobs. Must be one of: `"on_demand"` or `"slot_based"`
-- `reservation_ids` (required when enabled): List of reservation IDs in the format "project:region.reservation-name"
+- `enabled` (required): Must be `true` to run optimization. If omitted, `false`, or the variable is not set, each BigQuery submit bypasses optimization (no API call). Takes effect on the next job without restarting Airflow.
+- `default_pricing_mode` (required when `enabled` is `true`): The default pricing mode for jobs. Must be one of: `"on_demand"` or `"slot_based"`
+- `reservation_ids` (required when `enabled` is `true`): List of reservation IDs in the format "project:region.reservation-name"
 
 ### Setting the Configuration
 
@@ -128,6 +128,7 @@ You can set the configuration in two ways:
 1. Using the Airflow CLI:
 ```bash
 airflow variables set rabbit_bq_optimizer_config '{
+    "enabled": true,
     "default_pricing_mode": "on_demand",
     "reservation_ids": [
         "project:region.reservation-name1",
@@ -332,6 +333,7 @@ If you see this on job submit, the Airflow variable `rabbit_bq_optimizer_config`
 2. Set valid JSON content that includes all required fields:
    ```json
    {
+       "enabled": true,
        "default_pricing_mode": "on_demand",
        "reservation_ids": [
            "project:us-central1.reservation-name1",

--- a/bq-job-optimizer-airflow-2/README.md
+++ b/bq-job-optimizer-airflow-2/README.md
@@ -20,16 +20,16 @@ Already running an older version? See [Updating](#updating).
    - If using `requirements.txt`:
      ```txt
      rabbit-bq-job-optimizer==0.1.18
-     rabbit-bq-optimizer-airflow-plugin==1.0.0
+     rabbit-bq-optimizer-airflow-plugin==1.0.1
      ```
    - If using `constraints.txt`:
      ```txt
      rabbit-bq-job-optimizer==0.1.18
-     rabbit-bq-optimizer-airflow-plugin==1.0.0
+     rabbit-bq-optimizer-airflow-plugin==1.0.1
      ```
    - If using a custom Docker image, add to your Dockerfile:
      ```dockerfile
-     RUN pip install rabbit-bq-job-optimizer==0.1.18 rabbit-bq-optimizer-airflow-plugin==1.0.0
+     RUN pip install rabbit-bq-job-optimizer==0.1.18 rabbit-bq-optimizer-airflow-plugin==1.0.1
      ```
 
    The plugin registers via Airflow's plugin entry point — no file copy into `plugins/` is required.
@@ -59,7 +59,7 @@ Update to the new package versions in your environment dependencies:
 
 ```txt
 rabbit-bq-job-optimizer==0.1.18
-rabbit-bq-optimizer-airflow-plugin==1.0.0
+rabbit-bq-optimizer-airflow-plugin==1.0.1
 ```
 
 Apply the update using your platform's usual process, then restart Airflow components (including the triggerer if you use deferrable `BigQueryInsertJobOperator`). Your `rabbit_api` connection, `rabbit_bq_optimizer_config` variable, and DAGs are unchanged. If optimization fails, the plugin still submits the original job (fail-open).
@@ -106,6 +106,7 @@ The remaining optimizer configuration stays in an Airflow variable. Create a JSO
 
 ```json
 {
+    "enabled": true,
     "default_pricing_mode": "on_demand",
     "reservation_ids": [
         "project:region.reservation-name1",
@@ -116,8 +117,9 @@ The remaining optimizer configuration stays in an Airflow variable. Create a JSO
 
 ### Configuration Fields
 
-- `default_pricing_mode` (required): The default pricing mode for jobs. Must be one of: `"on_demand"` or `"slot_based"`
-- `reservation_ids` (required): List of reservation IDs in the format "project:region.reservation-name"
+- `enabled` (optional, default `true`): When `false`, or when the variable is not set, each BigQuery submit bypasses optimization (no API call). Takes effect on the next job without restarting Airflow.
+- `default_pricing_mode` (required when enabled): The default pricing mode for jobs. Must be one of: `"on_demand"` or `"slot_based"`
+- `reservation_ids` (required when enabled): List of reservation IDs in the format "project:region.reservation-name"
 
 ### Setting the Configuration
 
@@ -321,10 +323,10 @@ Broken plugin: `No module named 'rabbit_bq_job_optimizer'` — install `rabbit-b
 If you see this error, it means the rabbit-bq-job-optimizer package is missing from your Airflow environment. Install it by adding the package (https://pypi.org/project/rabbit-bq-job-optimizer/) to your Airflow requirements or environment.
 
 ```
-[2025-06-15, 17:25:20 UTC] {rabbit_bq_optimizer_plugin.py:82} WARNING - Rabbit BQ Optimizer: config error: 'Variable rabbit_bq_optimizer_config does not exist'. Using original job.
+[2025-06-15, 17:25:20 UTC] {rabbit_bq_optimizer_plugin.py} WARNING - Rabbit BQ Optimizer: config error: rabbit_bq_optimizer_config not set or invalid. Using original job.
 ```
 
-If you see this error, it means the Airflow variable `rabbit_bq_optimizer_config` is not set or has invalid content. Make sure you have:
+If you see this on job submit, the Airflow variable `rabbit_bq_optimizer_config` is not set or has invalid content. Make sure you have:
 
 1. Created the variable named exactly `rabbit_bq_optimizer_config`
 2. Set valid JSON content that includes all required fields:

--- a/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
+++ b/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
@@ -5,6 +5,10 @@ Patches ``BigQueryHook.insert_job`` so every BQ submit is optimized via the Rabb
 before ``jobs.insert``. Patches ``BigQueryInsertJobOperator._submit_job`` with a
 short-lived hook bridge so operator-driven submits can also route ``project_id`` to an
 on-demand pool when the optimizer sets ``optimizedJob.jobReference.projectId``.
+
+The ``rabbit_bq_optimizer_config`` variable is read once per job submit at the hook
+boundary; when missing or ``enabled`` is false, the original ``insert_job`` runs with no
+API call.
 """
 
 from __future__ import annotations
@@ -75,43 +79,51 @@ def _resolve_source_project(*, project_id: str | None, hook) -> str | None:
 
 def _load_optimizer_config() -> dict[str, Any] | None:
     try:
-        config = Variable.get(OPTIMIZER_VARIABLE, deserialize_json=True)
-        if not config:
-            raise KeyError(f"{OPTIMIZER_VARIABLE} is empty")
+        raw = Variable.get(OPTIMIZER_VARIABLE, deserialize_json=True)
+        # Variable missing, empty, or not a JSON object.
+        if not raw or not isinstance(raw, dict):
+            raise ValueError(f"{OPTIMIZER_VARIABLE} not set or invalid")
+
+        # Explicit opt-out; omitted key defaults to enabled.
+        enabled = raw.get("enabled", True)
+        if isinstance(enabled, str):
+            enabled = enabled.strip().lower() in ("true", "1", "yes", "on")
+        if not enabled:
+            logging.info(
+                "Rabbit BQ Optimizer: disabled via %s (enabled=false). Using original job.",
+                OPTIMIZER_VARIABLE,
+            )
+            return None
+
+        # Required optimizer input.
+        if "default_pricing_mode" not in raw:
+            raise ValueError("missing default_pricing_mode")
+
+        # Only supported pricing modes.
+        if raw["default_pricing_mode"] not in ("on_demand", "slot_based"):
+            raise ValueError(f"bad default_pricing_mode: {raw['default_pricing_mode']!r}")
+
+        config = dict(raw)
+        reservation_ids = config.get("reservation_ids") or []
+        # On-demand routing needs at least one reservation to compare against.
+        if config["default_pricing_mode"] == "on_demand" and not reservation_ids:
+            raise ValueError("on_demand default with no reservation_ids")
+        config["reservation_ids"] = reservation_ids
+        return config
     except (KeyError, ValueError) as exc:
+        # Missing variable, bad JSON, or failed validation above.
         logging.warning("Rabbit BQ Optimizer: config error: %s. Using original job.", exc)
         return None
-
-    if "default_pricing_mode" not in config:
-        logging.warning("Rabbit BQ Optimizer: missing default_pricing_mode. Using original job.")
-        return None
-
-    if config["default_pricing_mode"] not in ("on_demand", "slot_based"):
-        logging.warning("Rabbit BQ Optimizer: bad default_pricing_mode. Using original job.")
-        return None
-
-    config = dict(config)
-    reservation_ids = config.get("reservation_ids") or []
-    if config["default_pricing_mode"] == "on_demand" and not reservation_ids:
-        logging.warning(
-            "Rabbit BQ Optimizer: on_demand default with no reservation_ids. " "Using original job."
-        )
-        return None
-    config["reservation_ids"] = reservation_ids
-    return config
 
 
 def _optimize(
     *,
+    config: dict[str, Any],
     configuration: dict[str, Any],
     hook,
     project_id: str | None,
 ) -> tuple[dict[str, Any], str | None] | None:
     """Returns (optimized_configuration, pool_billing_project) or None."""
-    config = _load_optimizer_config()
-    if not config:
-        return None
-
     try:
         credentials = _load_rabbit_credentials()
     except Exception as exc:
@@ -214,9 +226,16 @@ def patch_bigquery_hook() -> None:
     original_insert_job = BigQueryHook.insert_job
 
     def patched_insert_job(self, *, configuration: dict, **kwargs) -> BigQueryJob:
+        config = _load_optimizer_config()
+        if not config:
+            return original_insert_job(self, configuration=configuration, **kwargs)
+
         operator = getattr(self, RABBIT_OPERATOR_BRIDGE_ATTR, None)
         outcome = _optimize(
-            configuration=configuration, hook=self, project_id=kwargs.get("project_id")
+            config=config,
+            configuration=configuration,
+            hook=self,
+            project_id=kwargs.get("project_id"),
         )
         if not outcome:
             return original_insert_job(self, configuration=configuration, **kwargs)

--- a/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
+++ b/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
@@ -7,8 +7,8 @@ short-lived hook bridge so operator-driven submits can also route ``project_id``
 on-demand pool when the optimizer sets ``optimizedJob.jobReference.projectId``.
 
 The ``rabbit_bq_optimizer_config`` variable is read once per job submit at the hook
-boundary; when missing or ``enabled`` is false, the original ``insert_job`` runs with no
-API call.
+boundary; optimization runs only when ``enabled`` is explicitly ``true``. Otherwise the
+original ``insert_job`` runs with no API call.
 """
 
 from __future__ import annotations
@@ -84,8 +84,15 @@ def _load_optimizer_config() -> dict[str, Any] | None:
         if not raw or not isinstance(raw, dict):
             raise ValueError(f"{OPTIMIZER_VARIABLE} not set or invalid")
 
-        # Explicit opt-out; omitted key defaults to enabled.
-        enabled = raw.get("enabled", True)
+        # Optimization is opt-in; enabled must be present and true.
+        if "enabled" not in raw:
+            logging.info(
+                "Rabbit BQ Optimizer: %s missing enabled field. Using original job.",
+                OPTIMIZER_VARIABLE,
+            )
+            return None
+
+        enabled = raw["enabled"]
         if isinstance(enabled, str):
             enabled = enabled.strip().lower() in ("true", "1", "yes", "on")
         if not enabled:

--- a/bq-job-optimizer-airflow-2/test_plugin_optimization.py
+++ b/bq-job-optimizer-airflow-2/test_plugin_optimization.py
@@ -55,7 +55,11 @@ class TestPluginOptimization(unittest.TestCase):
             patch.object(
                 Variable,
                 "get",
-                return_value={"enabled": True, "default_pricing_mode": "on_demand", "reservation_ids": ["p:US.r"]},
+                return_value={
+                    "enabled": True,
+                    "default_pricing_mode": "on_demand",
+                    "reservation_ids": ["p:US.r"],
+                },
             ),
             patch.object(
                 plugin_module,

--- a/bq-job-optimizer-airflow-2/test_plugin_optimization.py
+++ b/bq-job-optimizer-airflow-2/test_plugin_optimization.py
@@ -55,7 +55,7 @@ class TestPluginOptimization(unittest.TestCase):
             patch.object(
                 Variable,
                 "get",
-                return_value={"default_pricing_mode": "on_demand", "reservation_ids": ["p:US.r"]},
+                return_value={"enabled": True, "default_pricing_mode": "on_demand", "reservation_ids": ["p:US.r"]},
             ),
             patch.object(
                 plugin_module,
@@ -312,7 +312,10 @@ class TestPluginOptimization(unittest.TestCase):
             patch.object(
                 Variable,
                 "get",
-                return_value={"default_pricing_mode": "on_demand"},
+                return_value={
+                    "enabled": True,
+                    "default_pricing_mode": "on_demand",
+                },
             ),
             patch.object(
                 plugin_module,
@@ -353,7 +356,7 @@ class TestPluginOptimization(unittest.TestCase):
             patch.object(
                 Variable,
                 "get",
-                return_value={"default_pricing_mode": "slot_based"},
+                return_value={"enabled": True, "default_pricing_mode": "slot_based"},
             ),
             patch.object(
                 plugin_module,
@@ -444,6 +447,45 @@ class TestPluginOptimization(unittest.TestCase):
                 Variable,
                 "get",
                 side_effect=KeyError("Variable rabbit_bq_optimizer_config does not exist"),
+            ),
+            patch.object(plugin_module, "RabbitBQJobOptimizer", return_value=mock_client),
+        ):
+            plugin_module.patch_bigquery_hook()
+
+            hook = BigQueryHook(gcp_conn_id="google_cloud_default")
+            hook.insert_job(configuration=dict(original_config), project_id=SOURCE_PROJECT)
+
+        mock_client.optimize_job.assert_not_called()
+        self.assertEqual(submitted["configuration"], original_config)
+
+    def test_missing_enabled_field_skips_optimizer(self):
+        import importlib
+
+        import rabbit_bq_optimizer_plugin as plugin_module
+        from airflow.models import Variable
+        from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+
+        importlib.reload(plugin_module)
+
+        original_config = {"query": {"query": "SELECT 1", "useLegacySql": False}}
+        submitted: dict = {}
+
+        def fake_bq_submit(self, *, configuration, **kwargs):
+            submitted["configuration"] = configuration
+            return MagicMock(job_id="mock-job-no-enabled")
+
+        BigQueryHook.insert_job = fake_bq_submit
+
+        mock_client = MagicMock()
+
+        with (
+            patch.object(
+                Variable,
+                "get",
+                return_value={
+                    "default_pricing_mode": "on_demand",
+                    "reservation_ids": ["p:US.r"],
+                },
             ),
             patch.object(plugin_module, "RabbitBQJobOptimizer", return_value=mock_client),
         ):

--- a/bq-job-optimizer-airflow-2/test_plugin_optimization.py
+++ b/bq-job-optimizer-airflow-2/test_plugin_optimization.py
@@ -374,6 +374,87 @@ class TestPluginOptimization(unittest.TestCase):
         optimization_config = mock_client.optimize_job.call_args.kwargs["enabledOptimizations"][0]
         self.assertEqual(optimization_config.config["reservationIds"], [])
 
+    def test_disabled_via_enabled_false_skips_optimizer(self):
+        import importlib
+
+        import rabbit_bq_optimizer_plugin as plugin_module
+        from airflow.models import Variable
+        from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+
+        importlib.reload(plugin_module)
+
+        original_config = {"query": {"query": "SELECT 1", "useLegacySql": False}}
+        submitted: dict = {}
+
+        def fake_bq_submit(self, *, configuration, **kwargs):
+            submitted["configuration"] = configuration
+            return MagicMock(job_id="mock-job-disabled")
+
+        BigQueryHook.insert_job = fake_bq_submit
+
+        mock_client = MagicMock()
+
+        with (
+            patch.object(
+                Variable,
+                "get",
+                return_value={
+                    "enabled": False,
+                    "default_pricing_mode": "on_demand",
+                    "reservation_ids": ["p:US.r"],
+                },
+            ),
+            patch.object(
+                plugin_module,
+                "_load_rabbit_credentials",
+                return_value={"api_key": "k", "base_url": None},
+            ),
+            patch.object(plugin_module, "RabbitBQJobOptimizer", return_value=mock_client),
+        ):
+            plugin_module.patch_bigquery_hook()
+
+            hook = BigQueryHook(gcp_conn_id="google_cloud_default")
+            hook.insert_job(configuration=dict(original_config), project_id=SOURCE_PROJECT)
+
+        mock_client.optimize_job.assert_not_called()
+        self.assertEqual(submitted["configuration"], original_config)
+
+    def test_missing_variable_skips_optimizer(self):
+        import importlib
+
+        import rabbit_bq_optimizer_plugin as plugin_module
+        from airflow.models import Variable
+        from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+
+        importlib.reload(plugin_module)
+
+        original_config = {"query": {"query": "SELECT 1", "useLegacySql": False}}
+        submitted: dict = {}
+
+        def fake_bq_submit(self, *, configuration, **kwargs):
+            submitted["configuration"] = configuration
+            return MagicMock(job_id="mock-job-missing-var")
+
+        BigQueryHook.insert_job = fake_bq_submit
+
+        mock_client = MagicMock()
+
+        with (
+            patch.object(
+                Variable,
+                "get",
+                side_effect=KeyError("Variable rabbit_bq_optimizer_config does not exist"),
+            ),
+            patch.object(plugin_module, "RabbitBQJobOptimizer", return_value=mock_client),
+        ):
+            plugin_module.patch_bigquery_hook()
+
+            hook = BigQueryHook(gcp_conn_id="google_cloud_default")
+            hook.insert_job(configuration=dict(original_config), project_id=SOURCE_PROJECT)
+
+        mock_client.optimize_job.assert_not_called()
+        self.assertEqual(submitted["configuration"], original_config)
+
     def test_optimize_failure_fails_open(self):
         import importlib
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="rabbit-bq-optimizer-airflow-plugin",
-    version="1.0.0",
+    version="1.0.1",
     py_modules=["rabbit_bq_optimizer_plugin"],
     package_dir={"": "bq-job-optimizer-airflow-2"},
     install_requires=[

--- a/setup_local_test.sh
+++ b/setup_local_test.sh
@@ -140,6 +140,7 @@ fi
 # 2. Create Variable
 echo "Setting rabbit_bq_optimizer_config variable..."
 airflow variables set rabbit_bq_optimizer_config '{
+    "enabled": true,
     "default_pricing_mode": "on_demand",
     "reservation_ids": [
         "project:us-central1.test-reservation"


### PR DESCRIPTION
## Summary
- Add `enabled` field to `rabbit_bq_optimizer_config`. Config is read once per BigQuery job submit at the hook boundary; when optimization is skipped, the original `insert_job` runs with no API call.
- Bump package version to **1.0.1** and update install docs.

### Variable shape

```json
{
    "enabled": true,
    "default_pricing_mode": "on_demand",
    "reservation_ids": [
        "project:region.reservation-name"
    ]
}
```

`enabled` must be present and `true` for optimization to run. `default_pricing_mode` and `reservation_ids` are required when enabled.

### Default behavior

| `rabbit_bq_optimizer_config` state | Behavior |
|------------------------------------|----------|
| Variable **not set** | Original BQ job (no optimizer API call) |
| Invalid / empty JSON | Original BQ job (warning in logs) |
| Valid JSON but **`enabled` omitted** | Original BQ job (info log) |
| `"enabled": false` | Original BQ job (info log) |
| `"enabled": true` + valid config | Optimize as before |

Optimization is **opt-in**: existing configs without `"enabled": true` will not call the optimizer until the variable is updated.

To turn optimization on: set `"enabled": true` in **Admin → Variables**. Takes effect on the **next** job submit — no Airflow restart. Deploying new plugin code still requires an environment update.

## Test plan
- [x] `python -m unittest bq-job-optimizer-airflow-2/test_plugin_optimization.py` (10 tests)
- [ ] Publish `rabbit-bq-optimizer-airflow-plugin==1.0.1` to PyPI after merge
- [ ] Composer: confirm jobs skip without `"enabled": true`, then enable and confirm optimization runs