### PR TITLE
chore: bump version to 1.1.1 after 1.1.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="rabbit-bq-optimizer-airflow-plugin",
-    version="1.1.0",
+    version="1.1.1",
     py_modules=["rabbit_bq_optimizer_plugin"],
     package_dir={"": "bq-job-optimizer-airflow-2"},
     install_requires=[


### PR DESCRIPTION
Post-release version bump following PyPI publish of `rabbit-bq-optimizer-airflow-plugin==1.1.0`.


Made with [Cursor](https://cursor.com)