### PR TITLE
feat: forward statement-level opt-in to the optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the source code for Rabbit's Airflow plugins, specifica
 - Patches the BigQuery hook to transparently send job configurations to the Rabbit Job Optimizer service.
 - Authenticates via the official `rabbit-bq-job-optimizer` Python client (install the latest version for compatibility).
 - Retrieves the Rabbit API key (and optional base URL override) from the Airflow connection `rabbit_api` so secrets stay out of plain-text variables.
-- Reads optimization parameters (pricing mode, reservation IDs, etc.) from the `rabbit_bq_optimizer_config` Airflow variable. Optimization runs only when `"enabled": true` is set explicitly; otherwise BigQuery jobs are unchanged on each submit.
+- Reads optimization parameters (pricing mode, reservation IDs, etc.) from the `rabbit_bq_optimizer_config` Airflow variable. Optimization runs only when `"enabled": true` is set explicitly; otherwise BigQuery jobs are unchanged on each submit. Set `"statement_level": true` to opt into per-statement routing for multi-statement SCRIPTs (also requires the tenant's `bq_dynamic_pricing_statement_level` feature flag).
 
 Refer to `bq-job-optimizer-airflow-2/README.md` for installation, configuration, and the end-to-end test plan.
 

--- a/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
+++ b/bq-job-optimizer-airflow-2/rabbit_bq_optimizer_plugin.py
@@ -116,6 +116,12 @@ def _load_optimizer_config() -> dict[str, Any] | None:
         if config["default_pricing_mode"] == "on_demand" and not reservation_ids:
             raise ValueError("on_demand default with no reservation_ids")
         config["reservation_ids"] = reservation_ids
+        # Statement-level routing is opt-in. The plugin submits the server-rewritten query verbatim, so
+        # enabling it here is safe; it also requires the tenant's bq_dynamic_pricing_statement_level flag.
+        statement_level = config.get("statement_level", False)
+        if isinstance(statement_level, str):
+            statement_level = statement_level.strip().lower() in ("true", "1", "yes", "on")
+        config["statement_level"] = bool(statement_level)
         return config
     except (KeyError, ValueError) as exc:
         # Missing variable, bad JSON, or failed validation above.
@@ -210,6 +216,7 @@ def _optimize(
                 config={
                     "defaultPricingMode": config.get("default_pricing_mode"),
                     "reservationIds": config["reservation_ids"],
+                    **({"statementLevel": True} if config.get("statement_level") else {}),
                 },
             )
         ],

--- a/bq-job-optimizer-airflow-2/test_plugin_optimization.py
+++ b/bq-job-optimizer-airflow-2/test_plugin_optimization.py
@@ -381,6 +381,88 @@ class TestPluginOptimization(unittest.TestCase):
         optimization_config = mock_client.optimize_job.call_args.kwargs["enabledOptimizations"][0]
         self.assertEqual(optimization_config.config["reservationIds"], [])
 
+    def test_statement_level_flag_forwarded_to_optimizer(self):
+        import importlib
+
+        import rabbit_bq_optimizer_plugin as plugin_module
+        from airflow.models import Variable
+        from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+
+        importlib.reload(plugin_module)
+
+        def fake_bq_submit(self, *, configuration, **kwargs):
+            return MagicMock(job_id="mock-job-stmt-level")
+
+        BigQueryHook.insert_job = fake_bq_submit
+
+        mock_client = MagicMock()
+        mock_client.optimize_job.return_value = self._mock_optimizer_response(pool_project=None)
+
+        with (
+            patch.object(
+                Variable,
+                "get",
+                return_value={"enabled": True, "default_pricing_mode": "slot_based", "statement_level": True},
+            ),
+            patch.object(
+                plugin_module,
+                "_load_rabbit_credentials",
+                return_value={"api_key": "k", "base_url": None},
+            ),
+            patch.object(plugin_module, "RabbitBQJobOptimizer", return_value=mock_client),
+        ):
+            plugin_module.patch_bigquery_hook()
+
+            hook = BigQueryHook(gcp_conn_id="google_cloud_default")
+            hook.insert_job(
+                configuration={"query": {"query": "SELECT 1; SELECT 2", "useLegacySql": False}},
+                project_id=SOURCE_PROJECT,
+            )
+
+        optimization_config = mock_client.optimize_job.call_args.kwargs["enabledOptimizations"][0]
+        self.assertTrue(optimization_config.config.get("statementLevel"))
+
+    def test_statement_level_absent_when_not_configured(self):
+        import importlib
+
+        import rabbit_bq_optimizer_plugin as plugin_module
+        from airflow.models import Variable
+        from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+
+        importlib.reload(plugin_module)
+
+        def fake_bq_submit(self, *, configuration, **kwargs):
+            return MagicMock(job_id="mock-job-no-stmt-level")
+
+        BigQueryHook.insert_job = fake_bq_submit
+
+        mock_client = MagicMock()
+        mock_client.optimize_job.return_value = self._mock_optimizer_response(pool_project=None)
+
+        with (
+            patch.object(
+                Variable,
+                "get",
+                return_value={"enabled": True, "default_pricing_mode": "slot_based"},
+            ),
+            patch.object(
+                plugin_module,
+                "_load_rabbit_credentials",
+                return_value={"api_key": "k", "base_url": None},
+            ),
+            patch.object(plugin_module, "RabbitBQJobOptimizer", return_value=mock_client),
+        ):
+            plugin_module.patch_bigquery_hook()
+
+            hook = BigQueryHook(gcp_conn_id="google_cloud_default")
+            hook.insert_job(
+                configuration={"query": {"query": "SELECT 1", "useLegacySql": False}},
+                project_id=SOURCE_PROJECT,
+            )
+
+        optimization_config = mock_client.optimize_job.call_args.kwargs["enabledOptimizations"][0]
+        self.assertNotIn("statementLevel", optimization_config.config)
+
     def test_disabled_via_enabled_false_skips_optimizer(self):
         import importlib
 


### PR DESCRIPTION
Reads an optional `statement_level` boolean from the `rabbit_bq_optimizer_config` Airflow variable and forwards it to the optimizer as `config.statementLevel`. When enabled (and the tenant's `bq_dynamic_pricing_statement_level` flag is on), a multi-statement SCRIPT is routed per statement via the optimizer's query rewrite.

The plugin already submits the returned `configuration` verbatim (including the rewritten `query.query`), so no apply-path change is needed. Adds two unit tests (flag forwarded / absent).

Server-side feature: https://github.com/followrabbit-ai/rabbit-app/pull/7543

🤖 Generated with [Claude Code](https://claude.com/claude-code)